### PR TITLE
feat: user entity 설계 및 도메인 로직 구현

### DIFF
--- a/src/main/java/org/ticketing/user/domain/entity/User.java
+++ b/src/main/java/org/ticketing/user/domain/entity/User.java
@@ -1,0 +1,82 @@
+package org.ticketing.user.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.ticketing.user.domain.enums.UserRole;
+import org.ticketing.user.domain.enums.UserStatus;
+
+@Entity
+@Table(name = "p_user")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+    @Id
+    @GeneratedValue
+    private UUID userId;
+
+    @Column(name = "email", length = 100, nullable = false, unique = true)
+    private String email;
+
+    @Column(name = "name", length = 50, nullable = false)
+    private String name;
+
+    @Column(name = "phone", length = 20)
+    private String phone;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", length = 20, nullable = false)
+    private UserRole role;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private UserStatus status;
+
+    @Column(name = "slack_user_id", length = 50)
+    private String slackUserId;
+
+    public static User createGeneral(String email, String name, String phone) {
+        User user = new User();
+        user.email = email;
+        user.name = name;
+        user.phone = phone;
+        user.role = UserRole.GENERAL;
+        user.status = UserStatus.APPROVED; // 일반 회원은 즉시 승인 상태로 생성
+        return user;
+    }
+
+    public static User createClubAdmin(String email, String name, String phone) {
+        User user = new User();
+        user.email = email;
+        user.name = name;
+        user.phone = phone;
+        user.role = UserRole.CLUB_ADMIN;
+        user.status = UserStatus.PENDING; // 구단 관리자는 승인 대기 상태로 생성
+        return user;
+    }
+
+    public void approve() {
+        this.status = UserStatus.APPROVED;
+    }
+
+    public void reject() {
+        this.status = UserStatus.REJECTED;
+    }
+
+    public void delete() {
+        this.status = UserStatus.DELETED;
+    }
+
+    public boolean isActive() {
+        return this.status == UserStatus.APPROVED;
+    }
+}

--- a/src/main/java/org/ticketing/user/domain/enums/UserRole.java
+++ b/src/main/java/org/ticketing/user/domain/enums/UserRole.java
@@ -1,0 +1,7 @@
+package org.ticketing.user.domain.enums;
+
+public enum UserRole {
+    ADMIN,
+    GENERAL,
+    CLUB_ADMIN
+}

--- a/src/main/java/org/ticketing/user/domain/enums/UserStatus.java
+++ b/src/main/java/org/ticketing/user/domain/enums/UserStatus.java
@@ -1,0 +1,8 @@
+package org.ticketing.user.domain.enums;
+
+public enum UserStatus {
+    PENDING,
+    APPROVED,
+    REJECTED,
+    DELETED
+}


### PR DESCRIPTION
### 📎 관련 이슈
- close #3 

### 📌 작업 내용
- User 엔티티 설계 및 구현
- 사용자 역할(UserRole) 및 상태(UserStatus) Enum 정의
- 역할에 따른 사용자 생성 로직 분리 (GENERAL / CLUB_ADMIN)
- 사용자 상태 변경 로직(approve, reject, delete) 엔티티 내부에 구현
- 로그인 가능 여부 판단 메서드(isActive) 추가

### ✨ 변경 사항
- UUID 기반 User 엔티티 생성
- role, status 필드를 Enum으로 관리하도록 변경
- 사용자 생성 시 기본 상태 및 역할을 도메인 로직으로 처리
- 상태 변경 로직을 Service가 아닌 Entity에 위치하도록 설계
- 향후 Keycloak 및 Notification 확장을 고려한 구조로 설계


### 📝 리뷰 포인트 (선택)
- 도메인 로직을 엔티티에 포함한 구조가 적절한지
- 역할 및 상태 Enum 설계가 확장성 측면에서 적절한지
- User 생성 메서드 분리 방식이 적절한지

### 🧠 기타 참고 사항
- 인증(Authentication)은 향후 Keycloak을 통해 분리할 예정
- Slack 기반 알림 기능은 이후 Notification 서비스에서 별도로 구현 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced user management system with support for multiple user roles (Admin, General, Club Admin)
  * Added user approval workflow with status transitions (Pending, Approved, Rejected, Deleted)
  * User profiles now capture email, name, phone, and Slack integration details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->