### PR TITLE
chore: user-service common-module 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,15 @@ java {
 
 repositories {
 	mavenCentral()
+
+	maven {
+		name = "GitHubPackages"
+		url = uri("https://maven.pkg.github.com/3s-ticketing/common-module")
+		credentials {
+			username = System.getenv("GPR_USER")
+			password = System.getenv("GPR_TOKEN")
+		}
+	}
 }
 
 ext {
@@ -22,6 +31,9 @@ ext {
 }
 
 dependencies {
+	// 공통 모듈 (org.ticketing:common:2.0-SNAPSHOT 로 publish 됨)
+	implementation 'org.ticketing:common:2.0-SNAPSHOT'
+
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.cloud:spring-cloud-starter-config'
@@ -33,6 +45,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testRuntimeOnly 'com.h2database:h2'
 }
 
 dependencyManagement {

--- a/src/main/java/org/ticketing/user/UserServiceApplication.java
+++ b/src/main/java/org/ticketing/user/UserServiceApplication.java
@@ -2,8 +2,9 @@ package org.ticketing.user;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = JpaRepositoriesAutoConfiguration.class)
 public class UserServiceApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/org/ticketing/user/UserServiceApplication.java
+++ b/src/main/java/org/ticketing/user/UserServiceApplication.java
@@ -4,7 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration;
 
-@SpringBootApplication(exclude = JpaRepositoriesAutoConfiguration.class)
+@SpringBootApplication(
+	scanBasePackages = "org.ticketing",
+	exclude = JpaRepositoriesAutoConfiguration.class
+)
 public class UserServiceApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/org/ticketing/user/domain/entity/User.java
+++ b/src/main/java/org/ticketing/user/domain/entity/User.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.ticketing.common.domain.BaseEntity;
 import org.ticketing.user.domain.enums.UserRole;
 import org.ticketing.user.domain.enums.UserStatus;
 
@@ -18,7 +19,7 @@ import org.ticketing.user.domain.enums.UserStatus;
 @Table(name = "p_user")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User {
+public class User extends BaseEntity {
 
     @Id
     @GeneratedValue

--- a/src/test/java/org/ticketing/user/UserServiceApplicationTests.java
+++ b/src/test/java/org/ticketing/user/UserServiceApplicationTests.java
@@ -1,13 +1,60 @@
 package org.ticketing.user;
 
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.ticketing.user.domain.entity.User;
+import org.ticketing.user.infrastructure.repository.JpaUserRepository;
+
+@ActiveProfiles("test")
+@SpringBootTest(properties = {
+	"spring.config.import=optional:configserver:http://localhost:8888",
+	"eureka.client.enabled=false"
+})
 class UserServiceApplicationTests {
+
+	@Autowired
+	private JpaUserRepository jpaUserRepository;
 
 	@Test
 	void contextLoads() {
 	}
 
+	@Test
+	void user_저장시_BaseEntity의_생성시간이_자동으로_저장된다() {
+		// given
+		User user = User.createGeneral(
+			"test@example.com",
+			"테스트유저",
+			"010-1234-5678"
+		);
+
+		// when
+		User savedUser = jpaUserRepository.saveAndFlush(user);
+
+		// then
+		assertThat(savedUser.getCreatedAt()).isNotNull();
+	}
+
+	@Test
+	void user_수정시_BaseEntity의_수정시간이_자동으로_저장된다() {
+		// given
+		User user = User.createClubAdmin(
+			"admin@example.com",
+			"구단관리자",
+			"010-1234-5678"
+		);
+
+		User savedUser = jpaUserRepository.saveAndFlush(user);
+
+		// when
+		savedUser.approve();
+		User modifiedUser = jpaUserRepository.saveAndFlush(savedUser);
+
+		// then
+		assertThat(modifiedUser.getModifiedAt()).isNotNull();
+	}
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,18 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:user_service_test;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    database-platform: org.hibernate.dialect.H2Dialect
+    properties:
+      hibernate:
+        format_sql: true
+
+eureka:
+  client:
+    enabled: false


### PR DESCRIPTION
### 📎 관련 이슈
- close #7 

### 📌 작업 내용
- user-service에 common-module을 적용했습니다.
- User 엔티티에 common-module의 BaseEntity를 상속하여 공통 감사 필드를 사용할 수 있도록 수정했습니다.
- common-module 적용 후 발생한 JPA Repository 중복 등록 문제를 해결했습니다.
- 테스트 환경에서 BaseEntity의 생성/수정 시간 자동 저장 여부를 검증했습니다.

### ✨ 변경 사항
- `build.gradle`에 common-module 의존성 및 GitHub Packages 저장소 설정 추가
- 테스트용 H2 DB 의존성 추가
- `User` 엔티티가 `BaseEntity`를 상속하도록 수정
- `JpaRepositoriesAutoConfiguration` 제외 설정 추가
- `application-test.yml` 추가
- User 저장 시 `createdAt` 자동 저장 테스트 추가
- User 수정 시 `modifiedAt` 자동 저장 테스트 추가

### 📝 리뷰 포인트 (선택)
- common-module의 `JPAConfig`와 Spring Boot의 JPA Repository 자동 설정이 동시에 동작하면서 Repository Bean 중복 등록 문제가 발생해 `JpaRepositoriesAutoConfiguration`을 제외했습니다.
- User 엔티티에 `BaseEntity`를 적용하면서 `created_at`, `modified_at`, `deleted_at`, `created_by`, `modified_by`, `deleted_by` 공통 필드가 테이블에 포함됩니다.
- 테스트는 `test` profile과 H2 메모리 DB를 사용하도록 구성했습니다.

### 🧠 기타 참고 사항
- `./gradlew clean test` 성공 확인
- `./gradlew clean build` 성공 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration tests verifying automatic timestamp auditing and entity state transitions.

* **Chores**
  * Updated build to use an authenticated artifact source and added compile/test dependencies.
  * Configured an isolated test environment with an in-memory database and schema recreation for tests.
  * Adjusted application startup configuration and refined entity structure to inherit a common base.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->