### PR TITLE
ci: user-service GitHub Actions CI 도입

### DIFF
--- a/.github/workflows/user-service-ci.yml
+++ b/.github/workflows/user-service-ci.yml
@@ -1,0 +1,35 @@
+name: User Service CI
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - main
+  push:
+    branches:
+      - dev
+      - main
+      - feature/**
+      - feat/**
+
+jobs:
+  build-and-test:
+    name: Build and Test user-service
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: gradle
+
+      - name: Grant execute permission for Gradle wrapper
+        run: chmod +x ./gradlew
+
+      - name: Run tests
+        run: ./gradlew clean test

--- a/.github/workflows/user-service-ci.yml
+++ b/.github/workflows/user-service-ci.yml
@@ -11,6 +11,12 @@ on:
       - main
       - feature/**
       - feat/**
+      - fix/**
+      - chore/**
+
+permissions:
+  contents: read
+  packages: read
 
 jobs:
   build-and-test:
@@ -32,4 +38,7 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Run tests
+        env:
+          GPR_USER: ${{ github.actor }}
+          GPR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew clean test

--- a/build.gradle
+++ b/build.gradle
@@ -56,4 +56,11 @@ dependencyManagement {
 
 tasks.named('test') {
 	useJUnitPlatform()
+
+	systemProperty 'spring.profiles.active', 'test'
+	systemProperty 'spring.cloud.config.enabled', 'false'
+	systemProperty 'spring.cloud.config.fail-fast', 'false'
+	systemProperty 'spring.cloud.bootstrap.enabled', 'false'
+	systemProperty 'spring.cloud.discovery.enabled', 'false'
+	systemProperty 'eureka.client.enabled', 'false'
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,7 +3,7 @@ spring:
     name: user-service
 
   config:
-    import: "configserver:http://localhost:8888"
+    import: "optional:configserver:http://localhost:8888"
 
 eureka:
   client:

--- a/src/test/java/org/ticketing/user/UserServiceApplicationTests.java
+++ b/src/test/java/org/ticketing/user/UserServiceApplicationTests.java
@@ -10,10 +10,7 @@ import org.ticketing.user.domain.entity.User;
 import org.ticketing.user.infrastructure.repository.JpaUserRepository;
 
 @ActiveProfiles("test")
-@SpringBootTest(properties = {
-	"spring.config.import=optional:configserver:http://localhost:8888",
-	"eureka.client.enabled=false"
-})
+@SpringBootTest
 class UserServiceApplicationTests {
 
 	@Autowired

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,4 +1,14 @@
 spring:
+  application:
+    name: user-service
+
+  cloud:
+    config:
+      enabled: false
+      fail-fast: false
+    discovery:
+      enabled: false
+
   datasource:
     url: jdbc:h2:mem:user_service_test;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     driver-class-name: org.h2.Driver
@@ -13,6 +23,12 @@ spring:
       hibernate:
         format_sql: true
 
+  sql:
+    init:
+      mode: never
+
 eureka:
   client:
     enabled: false
+    register-with-eureka: false
+    fetch-registry: false

--- a/src/test/resources/bootstrap.yml
+++ b/src/test/resources/bootstrap.yml
@@ -1,0 +1,7 @@
+spring:
+  cloud:
+    bootstrap:
+      enabled: false
+    config:
+      enabled: false
+      fail-fast: false


### PR DESCRIPTION
### 📎 관련 이슈
- close #11 

### 📌 작업 내용
- user-service에 GitHub Actions 기반 CI 워크플로우를 추가했습니다.
- PR 및 push 시 Gradle 테스트가 자동으로 실행되도록 설정했습니다.
- CI 환경에서 Config Server와 Eureka Server 없이도 테스트가 실행될 수 있도록 테스트 설정을 분리했습니다.

### ✨ 변경 사항
- `.github/workflows/user-service-ci.yml` 추가
- `application-test.yml`에 테스트용 H2 DB 설정 추가
- 테스트 환경에서 Config Server / Eureka 의존성 비활성화
- `application.yaml`의 Config Server import를 optional 처리
- Gradle 테스트 실행 시 `test` 프로필이 적용되도록 설정
- `UserServiceApplicationTests`에서 테스트 프로필 적용

### 📝 리뷰 포인트 (선택)
- CI workflow 트리거 조건이 적절한지 확인 부탁드립니다.
- 테스트 환경에서 Config Server / Eureka 의존성을 제거한 방식이 적절한지 확인 부탁드립니다.
- `application.yaml`의 Config Server optional 처리 방향이 괜찮은지 확인 부탁드립니다.

### 🧠 기타 참고 사항
- Config Server와 Eureka Server를 종료한 상태에서 로컬 테스트를 통과했습니다.

```bash id="iz0fgn"
.\gradlew clean test
```
```
BUILD SUCCESSFUL
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Implemented automated continuous integration testing on pull requests and code pushes.
  * Enhanced test isolation by decoupling from external cloud service dependencies.

* **Bug Fixes**
  * Made Config Server connection optional, preventing application startup failures when unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->