### PR TITLE
feat: User-Service Keycloak JWT 인증 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 	implementation 'org.ticketing:common:2.0-SNAPSHOT'
 
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.cloud:spring-cloud-starter-config'
 

--- a/src/main/java/org/ticketing/user/UserServiceApplication.java
+++ b/src/main/java/org/ticketing/user/UserServiceApplication.java
@@ -3,16 +3,26 @@ package org.ticketing.user;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 
 @SpringBootApplication(
-	scanBasePackages = {
+	exclude = JpaRepositoriesAutoConfiguration.class
+)
+@ComponentScan(
+	basePackages = {
 		"org.ticketing.user",
 		"org.ticketing.config",
 		"org.ticketing.common.exception",
 		"org.ticketing.common.filter",
 		"org.ticketing.common.util"
 	},
-	exclude = JpaRepositoriesAutoConfiguration.class
+	excludeFilters = {
+		@ComponentScan.Filter(
+			type = FilterType.ASSIGNABLE_TYPE,
+			classes = org.ticketing.config.security.SecurityConfig.class
+		)
+	}
 )
 public class UserServiceApplication {
 

--- a/src/main/java/org/ticketing/user/infrastructure/config/UserSecurityConfig.java
+++ b/src/main/java/org/ticketing/user/infrastructure/config/UserSecurityConfig.java
@@ -1,0 +1,86 @@
+package org.ticketing.user.infrastructure.config;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableMethodSecurity
+@Profile("!test")
+public class UserSecurityConfig {
+
+    private static final String[] PERMIT_ALL_URLS = {
+        "/error",
+        "/actuator/health",
+
+        // 인증 없이 접근 가능해야 하는 API
+        "/api/v1/users/signup",
+        "/api/v1/users/login",
+        "/api/v1/users/refresh",
+
+        // Swagger 사용 시
+        "/swagger-ui/**",
+        "/v3/api-docs/**"
+    };
+
+    @Bean
+    public SecurityFilterChain userSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .sessionManagement(session ->
+                session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            )
+            .formLogin(formLogin -> formLogin.disable())
+            .httpBasic(httpBasic -> httpBasic.disable())
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers(PERMIT_ALL_URLS).permitAll()
+                .anyRequest().authenticated()
+            )
+            .oauth2ResourceServer(oauth2 -> oauth2
+                .jwt(jwt -> jwt.jwtAuthenticationConverter(keycloakJwtAuthenticationConverter()))
+            );
+
+        return http.build();
+    }
+
+    private Converter<Jwt, AbstractAuthenticationToken> keycloakJwtAuthenticationConverter() {
+        return jwt -> {
+            Collection<GrantedAuthority> authorities = new ArrayList<>();
+
+            Map<String, Object> realmAccess = jwt.getClaim("realm_access");
+            if (realmAccess != null && realmAccess.get("roles") instanceof List<?> roles) {
+                roles.forEach(role -> authorities.add(
+                    new SimpleGrantedAuthority("ROLE_" + role)
+                ));
+            }
+
+            Map<String, Object> resourceAccess = jwt.getClaim("resource_access");
+            if (resourceAccess != null) {
+                resourceAccess.values().forEach(resource -> {
+                    if (resource instanceof Map<?, ?> resourceMap
+                        && resourceMap.get("roles") instanceof List<?> roles) {
+                        roles.forEach(role -> authorities.add(
+                            new SimpleGrantedAuthority("ROLE_" + role)
+                        ));
+                    }
+                });
+            }
+
+            return new JwtAuthenticationToken(jwt, authorities, jwt.getSubject());
+        };
+    }
+}


### PR DESCRIPTION
### 📎 관련 이슈
- close #13 

### 📌 작업 내용
- User-Service에서 Keycloak이 발급한 Access Token을 검증할 수 있도록 JWT 인증을 연동했습니다.
- Spring Security OAuth2 Resource Server 의존성을 추가했습니다.
- User-Service 전용 `UserSecurityConfig`를 추가하여 보호 API에 JWT 인증을 적용했습니다.
- 기존 common-module의 `SecurityConfig`가 모든 요청을 허용하는 구조였기 때문에, User-Service에서는 해당 설정이 로딩되지 않도록 제외 처리했습니다.
- 인증이 필요 없는 API와 인증이 필요한 API를 분리했습니다.

### ✨ 변경 사항
- `build.gradle`
  - `spring-boot-starter-security` 의존성 추가
  - `spring-boot-starter-oauth2-resource-server` 의존성 추가

- `UserServiceApplication`
  - common-module의 `org.ticketing.config.security.SecurityConfig`를 ComponentScan 대상에서 제외
  - User-Service 자체 보안 설정이 적용되도록 구성

- `UserSecurityConfig`
  - CSRF 비활성화
  - Stateless 세션 정책 적용
  - Form Login / HTTP Basic 비활성화
  - 회원가입, 로그인, 토큰 재발급, 헬스체크, Swagger 경로는 인증 없이 접근 허용
  - 그 외 요청은 JWT 인증 필요하도록 설정
  - Keycloak JWT의 Realm Role / Client Role을 Spring Security 권한으로 변환

### 📝 리뷰 포인트 (선택)
- common-module의 기존 `SecurityConfig`를 제외하고 User-Service 전용 보안 설정을 적용한 방식이 적절한지 확인 부탁드립니다.

### 🧠 기타 참고 사항
- Config Server의 `user-service.yml`에는 아래 설정이 필요합니다.

```yaml
spring:
  security:
    oauth2:
      resourceserver:
        jwt:
          issuer-uri: http://localhost:18080/realms/ticketing
```

- 로컬 테스트 결과:
  - Access Token 없이 보호 API 요청 시 `401 Unauthorized` 응답 확인
  - Keycloak Access Token 포함 요청 시 `200 OK` 응답 확인
  - `./gradlew clean test` 성공 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented OAuth2 and JWT token-based authentication for API endpoint security.
  * Public endpoints for health checks, error handling, and API documentation remain accessible without authentication.
  * All other endpoints now require valid authentication tokens.

* **Chores**
  * Added Spring Security and OAuth2 Resource Server dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->