### PR TITLE
fix: User-Service 인증 제외 경로 수정

### DIFF
--- a/src/main/java/org/ticketing/user/infrastructure/config/UserSecurityConfig.java
+++ b/src/main/java/org/ticketing/user/infrastructure/config/UserSecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -27,11 +28,6 @@ public class UserSecurityConfig {
         "/error",
         "/actuator/health",
 
-        // 인증 없이 접근 가능해야 하는 API
-        "/api/v1/users/signup",
-        "/api/v1/users/login",
-        "/api/v1/users/refresh",
-
         // Swagger 사용 시
         "/swagger-ui/**",
         "/v3/api-docs/**"
@@ -48,6 +44,14 @@ public class UserSecurityConfig {
             .httpBasic(httpBasic -> httpBasic.disable())
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(PERMIT_ALL_URLS).permitAll()
+
+                // 회원가입
+                .requestMatchers(HttpMethod.POST, "/api/users").permitAll()
+
+                // 로그인
+                .requestMatchers(HttpMethod.POST, "/api/auth/login").permitAll()
+
+                // 그 외 요청은 인증 필요
                 .anyRequest().authenticated()
             )
             .oauth2ResourceServer(oauth2 -> oauth2


### PR DESCRIPTION
### 📎 관련 이슈
- close #16 

### 📌 작업 내용
- User-Service의 JWT 인증 제외 경로를 현재 API 명세서 기준으로 수정했습니다.
- 기존에는 인증 제외 경로가 `/api/v1/users/signup`, `/api/v1/users/login`, `/api/v1/users/refresh` 기준으로 설정되어 있었습니다.
- 현재 API 명세서 기준에 맞춰 회원가입과 로그인 API만 인증 없이 접근 가능하도록 변경했습니다.
- 그 외 유저 조회, 수정, 삭제 등의 API는 기존처럼 JWT 인증이 필요하도록 유지했습니다.

### ✨ 변경 사항
- `UserSecurityConfig`
  - 기존 인증 제외 경로 제거
    - `/api/v1/users/signup`
    - `/api/v1/users/login`
    - `/api/v1/users/refresh`
  - `POST /api/users` 회원가입 요청 인증 제외
  - `POST /api/auth/login` 로그인 요청 인증 제외
  - `GET /api/users`, `GET /api/users/{userId}`, `PATCH /api/users/{userId}`, `DELETE /api/users/{userId}` 등 보호 API는 인증 필요 상태 유지
  - `HttpMethod` 기반으로 인증 제외 경로를 명확히 구분

### 📝 리뷰 포인트 (선택)
- `POST /api/users`, `POST /api/auth/login`만 인증 제외 처리하는 방식이 API 명세서와 맞는지 확인 부탁드립니다.
- `GET /api/users`와 같이 같은 URL이더라도 HTTP Method에 따라 인증 정책을 다르게 적용한 부분 확인 부탁드립니다.
- Gateway에서도 동일 경로를 인증 제외 처리하고 있어, User-Service 내부 Security 설정과 정책이 일치하는지 확인 부탁드립니다.


### 🧠 기타 참고 사항
- 기대 동작:
  - Access Token 없이 `POST /api/users` 요청 시 회원가입 가능
  - Access Token 없이 `POST /api/auth/login` 요청 시 로그인 가능
  - Access Token 없이 `GET /api/users` 요청 시 `401 Unauthorized`
  - 유효한 Access Token 포함 후 `GET /api/users` 요청 시 `200 OK`

- 관련 작업:
  - Gateway JWT 인증 필터 연동 작업과 연관된 User-Service 인증 경로 정리입니다.