### PR TITLE
chore: User Service Config Server 주소 변경

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,9 +3,4 @@ spring:
     name: user-service
 
   config:
-    import: "optional:configserver:http://localhost:8888"
-
-eureka:
-  client:
-    service-url:
-      defaultZone: http://localhost:17001/eureka/
+    import: optional:configserver:http://localhost:10002


### PR DESCRIPTION
### 📎 관련 이슈
- close #18 

### 📌 작업 내용
- User Service가 바라보는 Config Server 주소를 기존 `8888`에서 `10002`로 변경했습니다.
- User Service 내부에 있던 Eureka Server 주소 설정을 제거하고, config-repo에서 중앙 관리하도록 정리했습니다.

### ✨ 변경 사항
- `spring.config.import` 수정
  - 기존: `optional:configserver:http://localhost:8888`
  - 변경: `optional:configserver:http://localhost:10002`
- User Service 내부 `application.yml`에서 Eureka Client 설정 제거
  - Eureka 설정은 `config-repo/user-service.yml`에서 관리

### 📝 리뷰 포인트 (선택)
- User Service가 변경된 Config Server 포트(`10002`)를 바라보는지 확인 부탁드립니다.
- Eureka Client 설정을 서비스 내부가 아닌 config-repo에서 관리하는 방향이 적절한지 확인 부탁드립니다.

### 🧠 기타 참고 사항
- User Service의 실제 실행 포트, datasource, security, Eureka Client 설정은 `config-repo/user-service.yml`에서 관리합니다.
- 실행 순서:
  1. Config Server (`10002`)
  2. Eureka Server (`10001`)
  3. User Service (`20001`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Updated the configuration server connection endpoint to use a new address
  * Removed service discovery configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->