### PR TITLE
feat: Keycloak Admin Client 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 
+	// Keycloak Admin Client
+	implementation 'org.keycloak:keycloak-admin-client:26.0.0'
+
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.cloud:spring-cloud-starter-config'
 

--- a/src/main/java/org/ticketing/user/infrastructure/config/KeycloakConfig.java
+++ b/src/main/java/org/ticketing/user/infrastructure/config/KeycloakConfig.java
@@ -1,0 +1,30 @@
+package org.ticketing.user.infrastructure.config;
+
+import org.keycloak.OAuth2Constants;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.KeycloakBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class KeycloakConfig {
+
+    @Bean
+    public Keycloak keycloakAdminClient(
+        @Value("${keycloak.server-url}") String serverUrl,
+        @Value("${keycloak.admin-realm}") String adminRealm,
+        @Value("${keycloak.admin-client-id}") String adminClientId,
+        @Value("${keycloak.admin-username}") String adminUsername,
+        @Value("${keycloak.admin-password}") String adminPassword
+    ) {
+        return KeycloakBuilder.builder()
+            .serverUrl(serverUrl)
+            .realm(adminRealm)
+            .clientId(adminClientId)
+            .username(adminUsername)
+            .password(adminPassword)
+            .grantType(OAuth2Constants.PASSWORD)
+            .build();
+    }
+}

--- a/src/main/java/org/ticketing/user/infrastructure/config/KeycloakConfig.java
+++ b/src/main/java/org/ticketing/user/infrastructure/config/KeycloakConfig.java
@@ -6,8 +6,10 @@ import org.keycloak.admin.client.KeycloakBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 @Configuration
+@Profile("!test")
 public class KeycloakConfig {
 
     @Bean

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,4 +3,12 @@ spring:
     name: user-service
 
   config:
-    import: optional:configserver:http://localhost:10002
+    import: ${SPRING_CONFIG_IMPORT:optional:configserver:http://localhost:10002}
+
+keycloak:
+  server-url: ${KEYCLOAK_SERVER_URL:http://localhost:18080}
+  realm: ${KEYCLOAK_REALM:ticketing}
+  admin-realm: ${KEYCLOAK_ADMIN_REALM:master}
+  admin-client-id: ${KEYCLOAK_ADMIN_CLIENT_ID:admin-cli}
+  admin-username: ${KEYCLOAK_ADMIN_USERNAME:admin}
+  admin-password: ${KEYCLOAK_ADMIN_PASSWORD}


### PR DESCRIPTION
### 📎 관련 이슈
- close #24

### 📌 작업 내용
- user-service에서 Keycloak Admin API를 사용할 수 있도록 Keycloak Admin Client 설정을 추가했습니다.
- Keycloak Admin Client 의존성을 추가했습니다.
- Keycloak 서버 URL, realm, admin realm, admin client 정보를 application.yaml에 추가했습니다.
- Keycloak Admin Client를 Spring Bean으로 등록했습니다.

### ✨ 변경 사항
- build.gradle에 `keycloak-admin-client` 의존성 추가
- application.yaml에 Keycloak 설정 추가
- `KeycloakConfig` 추가
- Keycloak 관리자 비밀번호는 기본값 없이 `KEYCLOAK_ADMIN_PASSWORD` 환경변수로만 주입되도록 설정

### 📝 리뷰 포인트 (선택)
- Keycloak 설정값의 환경변수명이 적절한지 확인 부탁드립니다.
- `KeycloakConfig`의 Admin Client Bean 생성 방식이 user-service 구조에 적절한지 확인 부탁드립니다.
- 관리자 비밀번호를 기본값 없이 환경변수로만 주입하는 방식이 적절한지 확인 부탁드립니다.

### 🧠 기타 참고 사항
- 이번 PR은 Keycloak Admin Client 설정까지만 포함합니다.
- 회원가입 시 Keycloak 사용자를 생성하는 실제 로직은 별도 PR에서 진행할 예정입니다.