### PR TITLE
feat: 회원가입 시 Keycloak 사용자 생성 연동

### DIFF
--- a/src/main/java/org/ticketing/user/application/service/UserService.java
+++ b/src/main/java/org/ticketing/user/application/service/UserService.java
@@ -9,6 +9,7 @@ import org.ticketing.common.exception.ConflictException;
 import org.ticketing.common.exception.NotFoundException;
 import org.ticketing.user.domain.entity.User;
 import org.ticketing.user.domain.repository.UserRepository;
+import org.ticketing.user.infrastructure.keycloak.KeycloakUserService;
 
 @Service
 @RequiredArgsConstructor
@@ -16,12 +17,15 @@ import org.ticketing.user.domain.repository.UserRepository;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final KeycloakUserService keycloakUserService;
 
     @Transactional
-    public User signUp(String email, String name, String phone) {
+    public User signUp(String email, String password, String name, String phone) {
         if (userRepository.existsByEmailAndDeletedAtIsNull(email)) {
             throw new ConflictException("이미 존재하는 이메일입니다.");
         }
+
+        keycloakUserService.createUser(email, password, name);
 
         User user = User.createGeneral(email, name, phone);
 

--- a/src/main/java/org/ticketing/user/infrastructure/keycloak/KeycloakUserService.java
+++ b/src/main/java/org/ticketing/user/infrastructure/keycloak/KeycloakUserService.java
@@ -1,0 +1,90 @@
+package org.ticketing.user.infrastructure.keycloak;
+
+import jakarta.ws.rs.core.Response;
+import java.net.URI;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.representations.idm.CredentialRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.ticketing.common.exception.ConflictException;
+
+@Service
+@RequiredArgsConstructor
+public class KeycloakUserService {
+
+    private final Keycloak keycloak;
+
+    @Value("${keycloak.realm}")
+    private String realm;
+
+    public void createUser(String email, String password, String name) {
+        UserRepresentation user = new UserRepresentation();
+        user.setUsername(email);
+        user.setEmail(email);
+        user.setFirstName(name);
+        user.setLastName("User");
+        user.setEnabled(true);
+        user.setEmailVerified(true);
+        user.setRequiredActions(List.of());
+
+        Response response = keycloak.realm(realm)
+            .users()
+            .create(user);
+
+        int status = response.getStatus();
+
+        if (status == 409) {
+            response.close();
+            throw new ConflictException("이미 Keycloak에 존재하는 사용자입니다.");
+        }
+
+        if (status != 201) {
+            response.close();
+            throw new IllegalStateException("Keycloak 사용자 생성 실패. status=" + status);
+        }
+
+        String userId = extractCreatedUserId(response.getLocation());
+        response.close();
+
+        setPassword(userId, password);
+        clearRequiredActions(userId, name);
+    }
+
+    private void setPassword(String userId, String password) {
+        CredentialRepresentation credential = new CredentialRepresentation();
+        credential.setType(CredentialRepresentation.PASSWORD);
+        credential.setValue(password);
+        credential.setTemporary(false);
+
+        keycloak.realm(realm)
+            .users()
+            .get(userId)
+            .resetPassword(credential);
+    }
+
+    private void clearRequiredActions(String userId, String name) {
+        UserRepresentation createdUser = keycloak.realm(realm)
+            .users()
+            .get(userId)
+            .toRepresentation();
+
+        createdUser.setEnabled(true);
+        createdUser.setEmailVerified(true);
+        createdUser.setFirstName(name);
+        createdUser.setLastName("User");
+        createdUser.setRequiredActions(List.of());
+
+        keycloak.realm(realm)
+            .users()
+            .get(userId)
+            .update(createdUser);
+    }
+
+    private String extractCreatedUserId(URI location) {
+        String path = location.getPath();
+        return path.substring(path.lastIndexOf("/") + 1);
+    }
+}

--- a/src/main/java/org/ticketing/user/presentation/controller/external/UserController.java
+++ b/src/main/java/org/ticketing/user/presentation/controller/external/UserController.java
@@ -32,6 +32,7 @@ public class UserController {
         return UserResponse.from(
             userService.signUp(
                 request.email(),
+                request.password(),
                 request.name(),
                 request.phone()
             )

--- a/src/main/java/org/ticketing/user/presentation/dto/request/UserSignupRequest.java
+++ b/src/main/java/org/ticketing/user/presentation/dto/request/UserSignupRequest.java
@@ -3,11 +3,16 @@ package org.ticketing.user.presentation.dto.request;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 public record UserSignupRequest(
     @NotBlank(message = "이메일은 필수입니다.")
     @Email(message = "이메일 형식이 올바르지 않습니다.")
     String email,
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+    String password,
 
     @NotBlank(message = "이름은 필수입니다.")
     String name,

--- a/src/test/java/org/ticketing/user/UserServiceApplicationTests.java
+++ b/src/test/java/org/ticketing/user/UserServiceApplicationTests.java
@@ -6,7 +6,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.ticketing.user.domain.entity.User;
+import org.ticketing.user.infrastructure.keycloak.KeycloakUserService;
 import org.ticketing.user.infrastructure.repository.JpaUserRepository;
 
 @ActiveProfiles("test")
@@ -15,6 +17,9 @@ class UserServiceApplicationTests {
 
 	@Autowired
 	private JpaUserRepository jpaUserRepository;
+
+	@MockitoBean
+	private KeycloakUserService keycloakUserService;
 
 	@Test
 	void contextLoads() {


### PR DESCRIPTION
### 📎 관련 이슈
- close #26 

### 📌 작업 내용
- 회원가입 요청 DTO에 password 필드를 추가했습니다.
- 회원가입 API에서 전달받은 password를 서비스 계층으로 전달하도록 수정했습니다.
- 회원가입 처리 시 Keycloak 사용자 생성 로직을 호출하도록 수정했습니다.
- Keycloak 사용자 생성, 비밀번호 설정, requiredActions 초기화 로직을 추가했습니다.
- Keycloak 사용자 중복 생성 시 `ConflictException`으로 처리하도록 구성했습니다.

### ✨ 변경 사항
- `UserSignupRequest`에 password 필드 및 검증 조건 추가
- `UserController`에서 password 전달 로직 추가
- `UserService`에서 DB 저장 전 Keycloak 사용자 생성 호출
- `KeycloakUserService` 추가
- Keycloak 사용자 생성 실패 및 중복 생성 예외 처리 추가

### 📝 리뷰 포인트 (선택)
- 회원가입 시 DB 저장 전에 Keycloak 사용자를 먼저 생성하는 흐름이 적절한지 확인 부탁드립니다.
- Keycloak 사용자 생성 실패 시 예외 처리 방식이 적절한지 확인 부탁드립니다.
- Keycloak 사용자 생성 후 비밀번호 설정 및 requiredActions 초기화 방식이 적절한지 확인 부탁드립니다.

### 🧠 기타 참고 사항
- Keycloak Admin Client 설정은 이전 PR에서 분리하여 처리했습니다.
- 이번 PR은 회원가입 시 Keycloak 사용자 생성 연동 로직만 포함합니다.
- `UserSecurityConfig.java`는 MVP 통합 테스트용 임시 보안 설정 PR에서 별도로 처리할 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * User registration now requires a password field during signup.
  * Password validation enforces security requirements: minimum 8 characters in length and cannot be blank.
  * Account creation workflow enhanced with improved security measures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->