### PR TITLE
fix: User service jwt 인증 로그 추가

### DIFF
--- a/src/main/java/org/ticketing/user/infrastructure/config/UserSecurityConfig.java
+++ b/src/main/java/org/ticketing/user/infrastructure/config/UserSecurityConfig.java
@@ -1,9 +1,11 @@
 package org.ticketing.user.infrastructure.config;
 
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -19,6 +21,7 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.security.web.SecurityFilterChain;
 
+@Slf4j
 @Configuration
 @EnableMethodSecurity
 @Profile("!test")
@@ -48,14 +51,34 @@ public class UserSecurityConfig {
                 // 회원가입
                 .requestMatchers(HttpMethod.POST, "/api/users").permitAll()
 
-                // 로그인
-                .requestMatchers(HttpMethod.POST, "/api/auth/login").permitAll()
-
                 // 내부 서비스 호출
                 .requestMatchers("/internal/users/**").permitAll()
 
-                // 그 외 요청은 인증 필요
+                // 그 외 요청은 Keycloak JWT 인증 필요
                 .anyRequest().authenticated()
+            )
+            .exceptionHandling(exception -> exception
+                .authenticationEntryPoint((request, response, authException) -> {
+                    log.warn(
+                        "[USER-401] method={} uri={} authHeaderPresent={} reason={}",
+                        request.getMethod(),
+                        request.getRequestURI(),
+                        request.getHeader("Authorization") != null,
+                        authException.getMessage()
+                    );
+
+                    response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+                })
+                .accessDeniedHandler((request, response, accessDeniedException) -> {
+                    log.warn(
+                        "[USER-403] method={} uri={} reason={}",
+                        request.getMethod(),
+                        request.getRequestURI(),
+                        accessDeniedException.getMessage()
+                    );
+
+                    response.sendError(HttpServletResponse.SC_FORBIDDEN);
+                })
             )
             .oauth2ResourceServer(oauth2 -> oauth2
                 .jwt(jwt -> jwt.jwtAuthenticationConverter(keycloakJwtAuthenticationConverter()))
@@ -86,6 +109,13 @@ public class UserSecurityConfig {
                     }
                 });
             }
+
+            log.info(
+                "[USER-JWT] subject={} issuer={} authorities={}",
+                jwt.getSubject(),
+                jwt.getIssuer(),
+                authorities
+            );
 
             return new JwtAuthenticationToken(jwt, authorities, jwt.getSubject());
         };

--- a/src/main/java/org/ticketing/user/infrastructure/filter/UserRequestLoggingFilter.java
+++ b/src/main/java/org/ticketing/user/infrastructure/filter/UserRequestLoggingFilter.java
@@ -1,0 +1,59 @@
+package org.ticketing.user.infrastructure.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class UserRequestLoggingFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        String userIdHeader = request.getHeader("X-User-Id");
+
+        boolean hasAuth = authHeader != null && !authHeader.isBlank();
+
+        log.info(
+            "[USER-IN] method={} uri={} query={} authPresent={} authLength={} xUserId={}",
+            request.getMethod(),
+            request.getRequestURI(),
+            request.getQueryString(),
+            hasAuth,
+            hasAuth ? authHeader.length() : 0,
+            userIdHeader
+        );
+
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+            log.info(
+                "[USER-OUT] method={} uri={} status={} authenticated={} principal={}",
+                request.getMethod(),
+                request.getRequestURI(),
+                response.getStatus(),
+                authentication != null && authentication.isAuthenticated(),
+                authentication != null ? authentication.getName() : null
+            );
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,6 +5,13 @@ spring:
   config:
     import: ${SPRING_CONFIG_IMPORT:optional:configserver:http://localhost:10002}
 
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ${KEYCLOAK_ISSUER_URI:http://localhost:18080/realms/ticketing}
+          jwk-set-uri: ${KEYCLOAK_JWK_SET_URI:http://localhost:18080/realms/ticketing/protocol/openid-connect/certs}
+
 keycloak:
   server-url: ${KEYCLOAK_SERVER_URL:http://localhost:18080}
   realm: ${KEYCLOAK_REALM:ticketing}
@@ -12,3 +19,9 @@ keycloak:
   admin-client-id: ${KEYCLOAK_ADMIN_CLIENT_ID:admin-cli}
   admin-username: ${KEYCLOAK_ADMIN_USERNAME:admin}
   admin-password: ${KEYCLOAK_ADMIN_PASSWORD}
+
+logging:
+  level:
+    org.ticketing.user: DEBUG
+    org.springframework.security: DEBUG
+    org.springframework.security.oauth2: DEBUG


### PR DESCRIPTION
### 📎 관련 이슈
- close #30 

### 📌 작업 내용
- User Service에서 JWT 인증 실패 원인을 추적할 수 있도록 요청/응답 로그를 추가했습니다.
- Gateway를 통해 전달된 Authorization 헤더와 `X-User-Id` 헤더를 User Service에서 확인할 수 있도록 로그 필터를 추가했습니다.
- User Service의 JWT 검증 과정에서 발생하는 401/403 원인을 확인할 수 있도록 Security 예외 로그를 추가했습니다.
- Docker 환경에서 Keycloak JWT 검증이 정상 동작하도록 issuer-uri / jwk-set-uri 설정을 보완했습니다.

### ✨ 변경 사항
- `UserRequestLoggingFilter` 추가
  - 요청 method, uri, query 로그 출력
  - Authorization 헤더 존재 여부 및 길이 출력
  - `X-User-Id` 헤더 출력
  - 응답 status, 인증 여부, principal 출력
- `UserSecurityConfig` 수정
  - 인증 실패 시 `[USER-401]` 로그 출력
  - 권한 부족 시 `[USER-403]` 로그 출력
  - JWT 변환 시 subject, issuer, authorities 확인 로그 추가
- `application.yaml` 수정
  - Docker 환경 기준 Keycloak JWT 검증 설정 보완
  - `issuer-uri`는 토큰의 `iss` 값과 일치하도록 설정
  - `jwk-set-uri`는 컨테이너 내부에서 Keycloak에 접근 가능한 주소로 설정

### 📝 리뷰 포인트 (선택)
- `UserRequestLoggingFilter`에서 토큰 원문을 직접 출력하지 않고 Authorization 헤더 존재 여부와 길이만 출력하도록 구성한 부분 확인 부탁드립니다.
- Gateway에서 전달한 `X-User-Id` 헤더가 User Service까지 정상 전달되는지 확인 부탁드립니다.
- User Service의 JWT `issuer-uri` / `jwk-set-uri` 설정이 Docker 환경 기준으로 적절한지 확인 부탁드립니다.
- 디버깅 로그가 통합 테스트 목적에 적절한 수준인지 확인 부탁드립니다.

### 🧠 기타 참고 사항
- Gateway 경유 `GET /api/users` 호출 성공 확인
- User Service 내부에서 발생하던 `The iss claim is not valid` 오류 해결 확인
- Gateway → User Service 라우팅 및 JWT 인증 흐름 정상 동작 확인
- 추후 운영/공유 환경에서는 Spring Security 및 OAuth2 관련 DEBUG 로그 레벨을 INFO로 낮추는 것이 필요합니다.