### PR TITLE
chore: user-service 모니터링 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 
+	// Monitoring
+	runtimeOnly 'org.springframework.boot:spring-boot-starter-actuator'
+	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
 	// Keycloak Admin Client
 	implementation 'org.keycloak:keycloak-admin-client:26.0.0'
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -25,3 +25,12 @@ logging:
     org.ticketing.user: DEBUG
     org.springframework.security: DEBUG
     org.springframework.security.oauth2: DEBUG
+
+management:
+  metrics:
+    tags:
+      application: ${spring.application.name}
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus


### PR DESCRIPTION
### 📎 관련 이슈
- close #32 

### 📌 작업 내용
- user-service 모니터링을 위해 Actuator 및 Prometheus 설정을 추가했습니다.
- `/actuator/health`, `/actuator/info`, `/actuator/prometheus` 엔드포인트가 노출되도록 management 설정을 추가했습니다.
- Prometheus에서 서비스별 메트릭을 구분할 수 있도록 application tag를 설정했습니다.

### ✨ 변경 사항
- `build.gradle`에 모니터링 관련 의존성 추가
  - `spring-boot-starter-actuator`
  - `micrometer-registry-prometheus`
- `application.yaml`에 Actuator endpoint 노출 설정 추가
- `management.metrics.tags.application` 설정 추가

### 📝 리뷰 포인트 (선택)
- Actuator / Prometheus 의존성 추가 방식이 적절한지 확인 부탁드립니다.
- `/actuator/health`, `/actuator/info`, `/actuator/prometheus` 노출 범위가 적절한지 확인 부탁드립니다.
- 추후 Config Server 중앙 설정으로 관리할 경우 해당 설정 위치를 config-repo로 이동할 필요가 있는지 확인 부탁드립니다.

### 🧠 기타 참고 사항
- 로컬 검증 예정 URL
  - `http://localhost:20001/actuator/health`
  - `http://localhost:20001/actuator/info`
  - `http://localhost:20001/actuator/prometheus`
- Prometheus / Grafana 연동은 추후 `ticketing-system` 레포에서 별도 설정 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added monitoring and metrics collection capabilities
  * Exposed health, info, and Prometheus metrics endpoints for system observability

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/3s-ticketing/user-service/pull/33)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->