### PR TITLE
feat: CLUB_ADMIN 가입 신청 및 승인 flow 추가

### DIFF
--- a/src/main/java/org/ticketing/user/application/service/UserService.java
+++ b/src/main/java/org/ticketing/user/application/service/UserService.java
@@ -8,6 +8,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.ticketing.common.exception.ConflictException;
 import org.ticketing.common.exception.NotFoundException;
 import org.ticketing.user.domain.entity.User;
+import org.ticketing.user.domain.enums.UserRole;
+import org.ticketing.user.domain.enums.UserStatus;
 import org.ticketing.user.domain.repository.UserRepository;
 import org.ticketing.user.infrastructure.keycloak.KeycloakUserService;
 
@@ -20,14 +22,24 @@ public class UserService {
     private final KeycloakUserService keycloakUserService;
 
     @Transactional
-    public User signUp(String email, String password, String name, String phone) {
+    public User signUp(String email, String password, String name, String phone, UserRole role) {
         if (userRepository.existsByEmailAndDeletedAtIsNull(email)) {
             throw new ConflictException("이미 존재하는 이메일입니다.");
         }
 
+        UserRole signUpRole = role == null ? UserRole.GENERAL : role;
+
+        if (signUpRole == UserRole.ADMIN) {
+            throw new IllegalArgumentException("관리자 계정은 직접 가입할 수 없습니다.");
+        }
+
         keycloakUserService.createUser(email, password, name);
 
-        User user = User.createGeneral(email, name, phone);
+        User user = switch (signUpRole) {
+            case GENERAL -> User.createGeneral(email, name, phone);
+            case CLUB_ADMIN -> User.createClubAdmin(email, name, phone);
+            case ADMIN -> throw new IllegalArgumentException("관리자 계정은 직접 가입할 수 없습니다.");
+        };
 
         return userRepository.save(user);
     }
@@ -49,6 +61,29 @@ public class UserService {
         User user = findUser(userId);
         user.update(name, phone);
         return user;
+    }
+
+    @Transactional
+    public void updateUserStatus(UUID userId, UserStatus status) {
+        User user = findUser(userId);
+
+        if (user.getRole() != UserRole.CLUB_ADMIN) {
+            throw new IllegalArgumentException("클럽 관리자 신청자만 승인 또는 거절할 수 있습니다.");
+        }
+
+        if (user.getStatus() != UserStatus.PENDING) {
+            throw new IllegalArgumentException("대기 상태의 클럽 관리자 신청만 처리할 수 있습니다.");
+        }
+
+        if (status != UserStatus.APPROVED && status != UserStatus.REJECTED) {
+            throw new IllegalArgumentException("가입 상태 변경은 APPROVED 또는 REJECTED만 가능합니다.");
+        }
+
+        if (status == UserStatus.APPROVED) {
+            user.approve();
+        } else {
+            user.reject();
+        }
     }
 
     @Transactional

--- a/src/main/java/org/ticketing/user/domain/entity/User.java
+++ b/src/main/java/org/ticketing/user/domain/entity/User.java
@@ -79,6 +79,10 @@ public class User extends BaseEntity {
         this.slackUserId = slackUserId;
     }
 
+    public void updateStatus(UserStatus status) {
+        this.status = status;
+    }
+
     public void approve() {
         this.status = UserStatus.APPROVED;
     }

--- a/src/main/java/org/ticketing/user/presentation/controller/external/UserController.java
+++ b/src/main/java/org/ticketing/user/presentation/controller/external/UserController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.ticketing.user.application.service.UserService;
 import org.ticketing.user.presentation.dto.request.UserSignupRequest;
 import org.ticketing.user.presentation.dto.request.UserUpdateRequest;
+import org.ticketing.user.presentation.dto.request.UserUpdateStatusRequest;
 import org.ticketing.user.presentation.dto.response.UserResponse;
 
 @RestController
@@ -34,7 +35,8 @@ public class UserController {
                 request.email(),
                 request.password(),
                 request.name(),
-                request.phone()
+                request.phone(),
+                request.role()
             )
         );
     }
@@ -66,6 +68,15 @@ public class UserController {
                 request.phone()
             )
         );
+    }
+
+    @PatchMapping("/{userId}/status")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void updateUserStatus(
+        @PathVariable UUID userId,
+        @Valid @RequestBody UserUpdateStatusRequest request
+    ) {
+        userService.updateUserStatus(userId, request.status());
     }
 
     @DeleteMapping("/{userId}")

--- a/src/main/java/org/ticketing/user/presentation/dto/request/UserSignupRequest.java
+++ b/src/main/java/org/ticketing/user/presentation/dto/request/UserSignupRequest.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import org.ticketing.user.domain.enums.UserRole;
 
 public record UserSignupRequest(
     @NotBlank(message = "이메일은 필수입니다.")
@@ -18,5 +19,7 @@ public record UserSignupRequest(
     String name,
 
     @Pattern(regexp = "^010-\\d{4}-\\d{4}$", message = "전화번호 형식은 010-0000-0000 이어야 합니다.")
-    String phone
+    String phone,
+
+    UserRole role
 ) {}

--- a/src/main/java/org/ticketing/user/presentation/dto/request/UserUpdateStatusRequest.java
+++ b/src/main/java/org/ticketing/user/presentation/dto/request/UserUpdateStatusRequest.java
@@ -1,0 +1,10 @@
+package org.ticketing.user.presentation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import org.ticketing.user.domain.enums.UserStatus;
+
+public record UserUpdateStatusRequest(
+
+    @NotNull(message = "변경할 회원 상태는 필수입니다.")
+    UserStatus status
+) {}


### PR DESCRIPTION
### 📎 관련 이슈
- close #34 

### 📌 작업 내용
- 회원가입 요청에 role 필드를 추가했습니다.
- role 미전달 시 일반 사용자(GENERAL)로 가입되도록 처리했습니다.
- 일반 사용자는 가입 즉시 APPROVED 상태로 생성되도록 했습니다.
- 클럽 관리자(CLUB_ADMIN)는 가입 시 PENDING 상태로 생성되도록 했습니다.
- ADMIN 권한으로 직접 가입하는 요청은 차단했습니다.
- 클럽 관리자 신청자의 상태를 APPROVED 또는 REJECTED로 변경하는 API를 추가했습니다.

### ✨ 변경 사항
- `UserSignupRequest`에 `role` 필드 추가
- `UserService.signUp()`에서 가입 role 분기 처리 추가
- `User.createClubAdmin()` 추가
- `PATCH /api/users/{userId}/status` API 추가
- PENDING 상태의 CLUB_ADMIN 신청자만 승인/거절 가능하도록 검증 추가

### 📝 리뷰 포인트
- CLUB_ADMIN 가입 시 PENDING 상태로 생성되는 흐름이 적절한지 확인 부탁드립니다.
- 상태 변경 API에서 CLUB_ADMIN + PENDING 사용자만 APPROVED/REJECTED 처리하도록 제한한 방식이 적절한지 확인 부탁드립니다.
- Gateway 권한 제한은 후속 작업에서 ADMIN only로 적용할 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now specify their role during registration with validation preventing self-registration as administrators
  * New capability to approve or reject club admin account requests through status management

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/3s-ticketing/user-service/pull/35)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->