### PR TITLE
feat: 회원가입 및 승인 시 Keycloak Role 자동 부여

### DIFF
--- a/src/main/java/org/ticketing/user/application/service/UserService.java
+++ b/src/main/java/org/ticketing/user/application/service/UserService.java
@@ -35,6 +35,10 @@ public class UserService {
 
         keycloakUserService.createUser(email, password, name);
 
+        if (signUpRole == UserRole.GENERAL) {
+            keycloakUserService.assignRealmRoleByEmail(email, UserRole.GENERAL.name());
+        }
+
         User user = switch (signUpRole) {
             case GENERAL -> User.createGeneral(email, name, phone);
             case CLUB_ADMIN -> User.createClubAdmin(email, name, phone);
@@ -81,6 +85,7 @@ public class UserService {
 
         if (status == UserStatus.APPROVED) {
             user.approve();
+            keycloakUserService.assignRealmRoleByEmail(user.getEmail(), UserRole.CLUB_ADMIN.name());
         } else {
             user.reject();
         }

--- a/src/main/java/org/ticketing/user/infrastructure/keycloak/KeycloakUserService.java
+++ b/src/main/java/org/ticketing/user/infrastructure/keycloak/KeycloakUserService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.representations.idm.CredentialRepresentation;
+import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -51,6 +52,30 @@ public class KeycloakUserService {
 
         setPassword(userId, password);
         clearRequiredActions(userId, name);
+    }
+
+    public void assignRealmRoleByEmail(String email, String roleName) {
+        List<UserRepresentation> users = keycloak.realm(realm)
+            .users()
+            .searchByEmail(email, true);
+
+        if (users.isEmpty()) {
+            throw new IllegalArgumentException("Keycloak 사용자를 찾을 수 없습니다. email=" + email);
+        }
+
+        String keycloakUserId = users.get(0).getId();
+
+        RoleRepresentation role = keycloak.realm(realm)
+            .roles()
+            .get(roleName)
+            .toRepresentation();
+
+        keycloak.realm(realm)
+            .users()
+            .get(keycloakUserId)
+            .roles()
+            .realmLevel()
+            .add(List.of(role));
     }
 
     private void setPassword(String userId, String password) {


### PR DESCRIPTION
### 📎 관련 이슈
- close #36

### 📌 작업 내용
- 회원가입 및 클럽 관리자 승인 흐름에서 Keycloak Realm Role이 자동 부여되도록 수정했습니다.
- 일반 회원 가입 시 `GENERAL` Role을 Keycloak 사용자에게 자동 부여하도록 처리했습니다.
- 클럽 관리자 승인 시 `CLUB_ADMIN` Role이 Keycloak 사용자에게 부여되도록 처리했습니다.
- Gateway에서 JWT Role 기반 권한 검증을 수행할 수 있도록 Keycloak 토큰에 서비스 Role이 포함되도록 개선했습니다.

### ✨ 변경 사항
- `KeycloakUserService`에서 Keycloak 사용자 Role 부여 로직 추가
  - 일반 회원 생성 시 `GENERAL` Role 부여
  - 클럽 관리자 승인 시 `CLUB_ADMIN` Role 부여
- `UserService`에서 회원 상태 변경 흐름과 Keycloak Role 부여 흐름 연동
  - 일반 회원은 생성 후 승인 상태 및 `GENERAL` Role 적용
  - 클럽 관리자 신청 계정은 승인 전까지 `CLUB_ADMIN` Role 미부여
  - 관리자 승인 후 `CLUB_ADMIN` Role 부여
- DB Role/Status와 Keycloak Role 상태가 일치하도록 처리했습니다.

### 📝 리뷰 포인트 (선택)
- 회원가입, 클럽 관리자 신청, 클럽 관리자 승인 흐름에서 DB Role/Status와 Keycloak Role 부여 시점이 적절한지 확인 부탁드립니다.
- Keycloak Realm Role 조회 및 부여 로직에서 예외 처리 방식이 적절한지 확인 부탁드립니다.
- Gateway에서 사용하는 JWT Role 정보와 user-service에서 부여하는 Keycloak Role 이름이 일치하는지 확인 부탁드립니다.

### 🧠 기타 참고 사항
- Gateway 권한 검증은 Keycloak JWT에 포함된 Role 정보를 기준으로 수행됩니다.
- 일반 회원은 회원가입 후 `GENERAL` Role이 바로 부여됩니다.
- 클럽 관리자 계정은 승인 전에는 `CLUB_ADMIN` Role이 부여되지 않고, 관리자 승인 후 재로그인 시 JWT에 `CLUB_ADMIN` Role이 포함됩니다.
- Postman 테스트 기준으로 일반 회원 JWT에는 `GENERAL`, 승인된 클럽 관리자 JWT에는 `CLUB_ADMIN` Role이 포함되는 것을 확인했습니다.