### PR TITLE
chore: user-service 자동 배포 파이프라인 구성

### DIFF
--- a/.github/workflows/user-service-deploy.yml
+++ b/.github/workflows/user-service-deploy.yml
@@ -1,0 +1,55 @@
+name: User Service CD
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: 3s-ticketing/user-service
+  IMAGE_TAG: main-latest
+
+jobs:
+  build-and-push:
+    name: Build and Push user-service image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: gradle
+
+      - name: Grant execute permission for Gradle wrapper
+        run: chmod +x ./gradlew
+
+      - name: Run tests
+        env:
+          GPR_USER: ${{ github.actor }}
+          GPR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew clean test
+
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Build Docker image
+        run: |
+          docker build \
+            -t $REGISTRY/$IMAGE_NAME:$IMAGE_TAG \
+            -t $REGISTRY/$IMAGE_NAME:${{ github.sha }} \
+            .
+
+      - name: Push Docker image
+        run: |
+          docker push $REGISTRY/$IMAGE_NAME:$IMAGE_TAG
+          docker push $REGISTRY/$IMAGE_NAME:${{ github.sha }}


### PR DESCRIPTION
### 📎 관련 이슈
- close #38 

### 📌 작업 내용
- user-service의 기존 CI workflow와 분리하여 CD workflow를 추가했습니다.
- main 브랜치 push 시 Docker 이미지 빌드 및 GHCR Push가 수행되도록 구성했습니다.
- 배포 자동화의 1차 단계로, EC2 재배포 전 Docker 이미지 생성/푸시까지 먼저 검증할 수 있도록 했습니다.

### ✨ 변경 사항
- `.github/workflows/user-service-deploy.yml` 추가
- main 브랜치 push 기준 CD workflow 구성
- JDK 17 환경 설정
- Gradle 테스트 실행
- GHCR 로그인 설정
- Docker 이미지 빌드 설정
- Docker 이미지 태그 추가
  - `ghcr.io/3s-ticketing/user-service:main-latest`
  - `ghcr.io/3s-ticketing/user-service:${{ github.sha }}`
- GHCR 이미지 Push 설정

### 📝 리뷰 포인트 (선택)
- 기존 `user-service-ci.yml`과 CD workflow를 분리한 구조가 적절한지 확인 부탁드립니다.
- CD 실행 기준을 `main` 브랜치 push로 제한한 것이 현재 배포 전략에 적절한지 확인 부탁드립니다.
- 이미지 태그를 `main-latest`와 commit hash 두 가지로 관리하는 방식이 적절한지 확인 부탁드립니다.

### 🧠 기타 참고 사항
- 현재 PR이 dev에 머지되어도 CD workflow는 실행되지 않습니다.
- CD workflow는 추후 dev에서 main으로 머지될 때 실행됩니다.
- 이번 작업은 GHCR 이미지 Push까지의 1차 자동화이며, 이후 EC2 SSH 접속 후 `docker compose pull/up` 기반 자동 재배포 단계를 추가할 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration and deployment automation for the user service, enabling faster and more reliable service updates with automated testing before each deployment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/3s-ticketing/user-service/pull/39)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->