### PR TITLE
fix: pass github package credentials to docker build

### DIFF
--- a/.github/workflows/user-service-deploy.yml
+++ b/.github/workflows/user-service-deploy.yml
@@ -45,6 +45,8 @@ jobs:
       - name: Build Docker image
         run: |
           docker build \
+            --build-arg GPR_USER=${{ secrets.GPR_USER }} \
+            --build-arg GPR_TOKEN=${{ secrets.GPR_TOKEN }} \
             -t $REGISTRY/$IMAGE_NAME:$IMAGE_TAG \
             -t $REGISTRY/$IMAGE_NAME:${{ github.sha }} \
             .


### PR DESCRIPTION
### 📎 관련 이슈
- close #41 

### 📌 작업 내용
- User Service CD workflow에서 Docker image build 중 GitHub Packages 인증 정보가 전달되지 않아 `common-module` 의존성 다운로드가 실패하던 문제를 수정했습니다.
- GitHub Actions의 Docker build 단계에서 `GPR_USER`, `GPR_TOKEN`을 build argument로 전달하도록 변경했습니다.

### ✨ 변경 사항
- `.github/workflows/user-service-deploy.yml` 수정
- Docker build 명령어에 GitHub Packages 인증 정보 전달 추가
  - `--build-arg GPR_USER=${{ secrets.GPR_USER }}`
  - `--build-arg GPR_TOKEN=${{ secrets.GPR_TOKEN }}`
- Docker build 내부에서 `common-module` 의존성 다운로드가 가능하도록 수정

### 📝 리뷰 포인트 (선택)
- Docker build 단계에서 `GPR_USER`, `GPR_TOKEN` build argument 전달 방식이 적절한지 확인 부탁드립니다.
- GitHub Actions Secrets에 등록된 `GPR_USER`, `GPR_TOKEN`을 사용하는 방식이 현재 CD 구조에 적절한지 확인 부탁드립니다.
- 추후 BuildKit secret 방식으로 개선할 필요가 있는지 검토 부탁드립니다.

### 🧠 기타 참고 사항
- 기존 실패 원인:
  - Docker build 내부에서 `common-module`을 GitHub Packages로부터 다운로드할 때 401 Unauthorized 발생
- 이번 수정 후 main 반영 시 `User Service CD` workflow를 다시 실행하여 Docker build 및 GHCR Push 성공 여부를 확인할 예정입니다.
- 현재 CD는 EC2 자동 재배포 전 단계이며, Docker image build 및 GHCR Push까지 수행합니다.