### PR TITLE
fix: apply GitHub Packages credentials to user-service CD

### DIFF
--- a/.github/workflows/user-service-deploy.yml
+++ b/.github/workflows/user-service-deploy.yml
@@ -45,6 +45,8 @@ jobs:
       - name: Build Docker image
         run: |
           docker build \
+            --build-arg GPR_USER=${{ secrets.GPR_USER }} \
+            --build-arg GPR_TOKEN=${{ secrets.GPR_TOKEN }} \
             -t $REGISTRY/$IMAGE_NAME:$IMAGE_TAG \
             -t $REGISTRY/$IMAGE_NAME:${{ github.sha }} \
             .


### PR DESCRIPTION
### 📎 관련 이슈
- 없음

### 📌 작업 내용
- Docker build 단계에서 GitHub Packages 인증 정보가 전달되지 않아 CD가 실패하던 문제를 수정했습니다.
- `GPR_USER`, `GPR_TOKEN`을 Docker build argument로 전달하도록 변경했습니다.

### ✨ 변경 사항
- `.github/workflows/user-service-deploy.yml` 수정
- Docker build 단계에 `--build-arg GPR_USER`, `--build-arg GPR_TOKEN` 추가

### 🧠 기타 참고 사항
- main 반영 후 User Service CD workflow가 다시 실행됩니다.
- 성공 시 GHCR에 user-service Docker image가 Push됩니다.