### PR TITLE
chore: user-service EC2 자동 배포 단계 추가

### DIFF
--- a/.github/workflows/user-service-deploy.yml
+++ b/.github/workflows/user-service-deploy.yml
@@ -55,3 +55,15 @@ jobs:
         run: |
           docker push $REGISTRY/$IMAGE_NAME:$IMAGE_TAG
           docker push $REGISTRY/$IMAGE_NAME:${{ github.sha }}
+
+      - name: Deploy user-service to EC2
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            cd ~/deploy/ticketing/ticketing-system
+            docker compose -f docker-compose.app.yml pull user-service
+            docker compose -f docker-compose.app.yml up -d --no-deps --force-recreate user-service
+            docker image prune -f

--- a/.github/workflows/user-service-deploy.yml
+++ b/.github/workflows/user-service-deploy.yml
@@ -63,7 +63,10 @@ jobs:
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
+            echo "${{ secrets.GPR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GPR_USER }} --password-stdin
             cd ~/deploy/ticketing/ticketing-system
             docker compose -f docker-compose.app.yml pull user-service
             docker compose -f docker-compose.app.yml up -d --no-deps --force-recreate user-service
+            docker ps --filter "name=ticketing-user-service"
             docker image prune -f
+            


### PR DESCRIPTION
### 📎 관련 이슈
- close #44

### 📌 작업 내용
- user-service CD workflow에 EC2 자동 배포 단계를 추가했습니다.
- 기존에는 main 브랜치 병합 시 Docker 이미지 build 및 GHCR push까지만 자동화되어 있었습니다.
- 이번 작업을 통해 GHCR 이미지 push 이후 EC2에 SSH로 접속하여 user-service 컨테이너를 자동 재배포하도록 구성했습니다.

### ✨ 변경 사항
- `user-service-deploy.yml`에 EC2 배포 step 추가
- GitHub Actions에서 EC2 접속 후 최신 user-service 이미지 pull
- `docker compose up -d --no-deps --force-recreate user-service` 명령으로 user-service만 재기동
- 배포 후 불필요한 Docker 이미지 정리를 위한 `docker image prune -f` 추가

### 📝 리뷰 포인트 (선택)
- GitHub Secrets 기반 EC2 접속 설정이 적절한지 확인 부탁드립니다.
  - `EC2_HOST`
  - `EC2_USER`
  - `EC2_SSH_KEY`
- 전체 서비스가 아닌 user-service만 재배포하도록 `--no-deps --force-recreate user-service` 옵션을 사용한 부분 확인 부탁드립니다.
- main 브랜치 병합 시 실제 EC2 자동 배포가 정상 동작하는지 확인이 필요합니다.

### 🧠 기타 참고 사항
- 현재 EC2에서 GHCR 로그인 후 수동으로 `docker compose pull user-service` 및 `docker compose up -d --no-deps --force-recreate user-service` 명령이 정상 동작함을 확인했습니다.
- 자동 배포 검증을 위해 EC2 보안 그룹의 SSH 22번 포트를 임시로 개방했습니다.
- 검증 완료 후 SSH 22번 포트는 다시 내 IP 기준으로 제한할 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment process for improved reliability and automation of service updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/3s-ticketing/user-service/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->