### PR TITLE
chore: user-service 자동 배포 설정 main 반영

### DIFF
--- a/.github/workflows/user-service-deploy.yml
+++ b/.github/workflows/user-service-deploy.yml
@@ -55,3 +55,15 @@ jobs:
         run: |
           docker push $REGISTRY/$IMAGE_NAME:$IMAGE_TAG
           docker push $REGISTRY/$IMAGE_NAME:${{ github.sha }}
+
+      - name: Deploy user-service to EC2
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            cd ~/deploy/ticketing/ticketing-system
+            docker compose -f docker-compose.app.yml pull user-service
+            docker compose -f docker-compose.app.yml up -d --no-deps --force-recreate user-service
+            docker image prune -f

--- a/.github/workflows/user-service-deploy.yml
+++ b/.github/workflows/user-service-deploy.yml
@@ -63,7 +63,10 @@ jobs:
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
+            echo "${{ secrets.GPR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GPR_USER }} --password-stdin
             cd ~/deploy/ticketing/ticketing-system
             docker compose -f docker-compose.app.yml pull user-service
             docker compose -f docker-compose.app.yml up -d --no-deps --force-recreate user-service
+            docker ps --filter "name=ticketing-user-service"
             docker image prune -f
+            


### PR DESCRIPTION
### 📎 관련 이슈
- close #44

### 📌 작업 내용
- dev 브랜치에 반영된 user-service EC2 자동 배포 설정을 main 브랜치에 반영합니다.
- main 브랜치 병합 시 GitHub Actions를 통해 Docker 이미지를 build/push하고, EC2에서 user-service 컨테이너를 자동 재배포하도록 구성했습니다.
- EC2 배포 시점마다 GHCR 인증을 수행하도록 `docker login ghcr.io` 단계를 추가했습니다.

### ✨ 변경 사항
- `user-service-deploy.yml`에 EC2 자동 배포 step 추가
- GHCR 이미지 push 이후 EC2 SSH 접속
- EC2 내부에서 GHCR 로그인 후 최신 user-service 이미지 pull
- `docker compose up -d --no-deps --force-recreate user-service`로 user-service만 재기동
- 배포 후 `docker image prune -f`로 불필요한 이미지 정리
- 배포 결과 확인을 위해 `docker ps --filter "name=ticketing-user-service"` 추가

### 📝 리뷰 포인트 (선택)
- main 병합 후 User Service CD workflow가 정상 실행되는지 확인이 필요합니다.
- GitHub Secrets 설정이 정상 적용되는지 확인이 필요합니다.
  - `GPR_USER`
  - `GPR_TOKEN`
  - `EC2_HOST`
  - `EC2_USER`
  - `EC2_SSH_KEY`
- 전체 서비스가 아닌 user-service만 재배포하도록 구성한 부분 확인 부탁드립니다.
- SHA 태그 기반 배포는 `ticketing-system`의 `docker-compose.app.yml`에서 `IMAGE_TAG` 변수화가 함께 필요하므로 후속 작업으로 분리합니다.

### 🧠 기타 참고 사항
- EC2에서 GHCR 로그인 후 수동으로 `docker compose pull user-service` 및 `docker compose up -d --no-deps --force-recreate user-service`가 정상 동작하는 것을 확인했습니다.
- 자동 배포 검증을 위해 SSH 22번 포트를 임시 개방한 상태입니다.
- 검증 완료 후 SSH 22번 포트는 다시 내 IP 기준으로 제한할 예정입니다.