### PR TITLE
chore: user-service workflow Secret 참조 방식 main 반영

### DIFF
--- a/.github/workflows/user-service-ci.yml
+++ b/.github/workflows/user-service-ci.yml
@@ -39,6 +39,6 @@ jobs:
 
       - name: Run tests
         env:
-          GPR_USER: ${{ github.actor }}
-          GPR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPR_USER: ${{ secrets.GPR_USER }}
+          GPR_TOKEN: ${{ secrets.GPR_TOKEN }}
         run: ./gradlew clean test

--- a/.github/workflows/user-service-deploy.yml
+++ b/.github/workflows/user-service-deploy.yml
@@ -35,12 +35,12 @@ jobs:
 
       - name: Run tests
         env:
-          GPR_USER: ${{ github.actor }}
-          GPR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPR_USER: ${{ secrets.GPR_USER }}
+          GPR_TOKEN: ${{ secrets.GPR_TOKEN }}
         run: ./gradlew clean test
 
       - name: Log in to GitHub Container Registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        run: echo "${{ secrets.GPR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GPR_USER }} --password-stdin
 
       - name: Build Docker image
         run: |
@@ -69,4 +69,3 @@ jobs:
             docker compose -f docker-compose.app.yml up -d --no-deps --force-recreate user-service
             docker ps --filter "name=ticketing-user-service"
             docker image prune -f
-            


### PR DESCRIPTION
### 📎 관련 이슈
- close #47

### 📌 작업 내용
- dev 브랜치에 반영된 user-service workflow Secret 참조 방식 정리 내용을 main 브랜치에 반영합니다.
- 기존 일부 단계에서 `github.actor`, `secrets.GITHUB_TOKEN`을 사용하던 부분을 `secrets.GPR_USER`, `secrets.GPR_TOKEN` 기준으로 통일했습니다.
- 다른 서비스 CI/CD workflow와 동일한 Secret 참조 규칙을 사용하도록 정리했습니다.

### ✨ 변경 사항
- `user-service-ci.yml` 수정
  - Gradle test 실행 시 `GPR_USER`, `GPR_TOKEN`을 Organization Secret 기준으로 사용
- `user-service-deploy.yml` 수정
  - Gradle test 실행 시 `GPR_USER`, `GPR_TOKEN`을 Organization Secret 기준으로 사용
  - GHCR login 단계에서 `secrets.GPR_TOKEN`, `secrets.GPR_USER` 사용
- 기존 EC2 자동 배포 흐름 유지
  - `docker compose pull user-service`
  - `docker compose up -d --no-deps --force-recreate user-service`

### 📝 리뷰 포인트 (선택)
- `GPR_USER`, `GPR_TOKEN` 참조 방식이 다른 서비스 workflow와 동일하게 맞춰졌는지 확인 부탁드립니다.
- main 병합 후 User Service CI/CD workflow가 정상 실행되는지 확인이 필요합니다.
- 기존 user-service EC2 자동 배포 흐름에 영향이 없는지 확인 부탁드립니다.

### 🧠 기타 참고 사항
- user-service의 EC2 자동 배포 흐름은 이전 작업에서 정상 동작을 확인했습니다.
- 이번 작업은 배포 로직 변경이 아니라 Secret 참조 방식 정리 작업입니다.
- main 병합 후 Actions 탭에서 CI/CD 성공 여부와 EC2 컨테이너 재기동 여부를 확인할 예정입니다.