### PR TITLE
fix: user-service GHCR 이미지 push 인증 방식 수정

### DIFF
--- a/.github/workflows/user-service-deploy.yml
+++ b/.github/workflows/user-service-deploy.yml
@@ -40,7 +40,7 @@ jobs:
         run: ./gradlew clean test
 
       - name: Log in to GitHub Container Registry
-        run: echo "${{ secrets.GPR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GPR_USER }} --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Build Docker image
         run: |


### PR DESCRIPTION
### 📎 관련 이슈
- close #50

### 📌 작업 내용
- user-service CD workflow에서 GHCR 이미지 push 단계의 인증 방식을 수정했습니다.
- 기존에는 GHCR image push 단계에서 `GPR_TOKEN`을 사용했으나, 권한 scope 문제로 push가 실패했습니다.
- Docker image push는 현재 레포의 GitHub Actions에서 발급되는 `GITHUB_TOKEN`을 사용하도록 변경했습니다.
- `GPR_TOKEN`은 common-module 다운로드와 EC2에서 GHCR image pull 용도로 유지했습니다.

### ✨ 변경 사항
- `user-service-deploy.yml` 수정
- GHCR image push 로그인 단계 변경
  - 기존: `secrets.GPR_TOKEN` / `secrets.GPR_USER`
  - 변경: `secrets.GITHUB_TOKEN` / `github.actor`
- 인증 토큰 역할 분리
  - Gradle test: `GPR_USER` / `GPR_TOKEN`
  - Docker build: `GPR_USER` / `GPR_TOKEN`
  - GHCR image push: `GITHUB_TOKEN` / `github.actor`
  - EC2 deploy pull: `GPR_USER` / `GPR_TOKEN`

### 📝 리뷰 포인트 (선택)
- GHCR image push 단계에서 `GITHUB_TOKEN`을 사용하도록 변경한 부분 확인 부탁드립니다.
- 기존 common-module 접근 및 EC2 pull에 사용하는 `GPR_TOKEN` 흐름에는 영향이 없는지 확인 부탁드립니다.
- User Service CD workflow가 main 병합 후 정상적으로 image build/push 및 EC2 배포까지 수행되는지 확인이 필요합니다.

### 🧠 기타 참고 사항
- 기존 실패 로그:
  - `denied: permission_denied: The token provided does not match expected scopes.`
- 이번 수정은 배포 로직 변경이 아니라 GHCR push 인증 방식 수정입니다.
- 동일한 인증 방식은 다른 서비스 CD workflow에도 일관되게 적용할 예정입니다.