### PR TITLE
fix: 서비스 배포 이미지를 GHCR 기반으로 변경

### DIFF
--- a/.github/workflows/user-service-deploy.yml
+++ b/.github/workflows/user-service-deploy.yml
@@ -40,7 +40,7 @@ jobs:
         run: ./gradlew clean test
 
       - name: Log in to GitHub Container Registry
-        run: echo "${{ secrets.GPR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GPR_USER }} --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Build Docker image
         run: |


### PR DESCRIPTION
### 📎 관련 이슈
- close #51 

### 📌 작업 내용
- dev 브랜치에 반영된 Docker Compose 서비스 이미지 설정 변경 사항을 main 브랜치에 반영합니다.
- 애플리케이션 서비스들이 EC2 로컬 `build` 방식이 아니라 GHCR에 push된 Docker image를 사용하도록 변경했습니다.
- 각 서비스별 CI/CD workflow에서 생성한 `main-latest` 이미지를 `docker compose pull/up`으로 배포할 수 있도록 compose 설정을 정리했습니다.

### ✨ 변경 사항
- `docker-compose.app.yml` 내 애플리케이션 서비스 배포 방식 변경
  - 기존: EC2 내부에서 `build` 기반 이미지 생성
  - 변경: GHCR image pull 기반 배포
- 서비스별 GHCR 이미지 참조 추가
  - `ghcr.io/3s-ticketing/user-service:main-latest`
  - `ghcr.io/3s-ticketing/club-service:main-latest`
  - `ghcr.io/3s-ticketing/match-service:main-latest`
  - `ghcr.io/3s-ticketing/seat-service:main-latest`
  - `ghcr.io/3s-ticketing/reservation-service:main-latest`
  - `ghcr.io/3s-ticketing/payment-service:main-latest`
  - `ghcr.io/3s-ticketing/queue-service:main-latest`
- 서비스별 CD workflow에서 실행하는 `docker compose pull {service-name}` 명령이 정상 동작할 수 있도록 설정 정리

### 📝 리뷰 포인트 (선택)
- 각 서비스명이 compose service명과 GHCR 이미지명 기준으로 올바르게 매핑되었는지 확인 부탁드립니다.
- 기존 `build` 블록 제거 후 `image` 기반 배포로 전환된 부분 확인 부탁드립니다.
- 아직 GHCR 이미지가 생성되지 않은 서비스는 전체 compose 재기동 시 pull 실패 가능성이 있으므로, 서비스별 CD 적용 후 순차적으로 배포 검증이 필요합니다.

### 🧠 기타 참고 사항
- user-service에서 GHCR 기반 이미지 pull 및 EC2 자동 배포 흐름을 먼저 검증했습니다.
- 각 서비스의 CI/CD workflow가 main 병합 시 GHCR에 `main-latest` 이미지를 push하고, EC2에서 해당 서비스만 재기동하는 구조로 확장 중입니다.
- EC2 반영 시 전체 서비스를 한 번에 재기동하기보다는 서비스별로 `docker compose pull/up`을 순차 검증하는 방식이 안전합니다.