### PR TITLE
[chore] user-service 다중 EC2 배포 설정 main 반영

### DIFF
--- a/.github/workflows/user-service-deploy.yml
+++ b/.github/workflows/user-service-deploy.yml
@@ -56,7 +56,7 @@ jobs:
           docker push $REGISTRY/$IMAGE_NAME:$IMAGE_TAG
           docker push $REGISTRY/$IMAGE_NAME:${{ github.sha }}
 
-      - name: Deploy user-service to EC2
+      - name: Deploy user-service to main-1 EC2
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.EC2_HOST }}
@@ -64,8 +64,76 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
             echo "${{ secrets.GPR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GPR_USER }} --password-stdin
+
             cd ~/deploy/ticketing/ticketing-system
+
+            git fetch origin
+            git reset --hard origin/dev
+
             docker compose -f docker-compose.app.yml pull user-service
             docker compose -f docker-compose.app.yml up -d --no-deps --force-recreate user-service
-            docker ps --filter "name=ticketing-user-service"
+
+            for i in {1..30}; do
+              if curl -fsS http://localhost:20001/actuator/health > /dev/null; then
+                echo "user-service on main-1 is healthy"
+                docker ps --filter "name=ticketing-user-service"
+                exit 0
+              fi
+
+              echo "Waiting for user-service on main-1... ($i/30)"
+              sleep 3
+            done
+
+            echo "user-service health check failed on main-1"
+            docker logs --tail=100 ticketing-user-service
+            exit 1
+
+      - name: Deploy user-service to main-2 EC2
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.EC2_HOST_2 }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            echo "${{ secrets.GPR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GPR_USER }} --password-stdin
+
+            cd ~/deploy/ticketing/ticketing-system
+
+            git fetch origin
+            git reset --hard origin/dev
+
+            docker compose -f docker-compose.app.yml pull user-service
+            docker compose -f docker-compose.app.yml up -d --no-deps --force-recreate user-service
+
+            for i in {1..30}; do
+              if curl -fsS http://localhost:20001/actuator/health > /dev/null; then
+                echo "user-service on main-2 is healthy"
+                docker ps --filter "name=ticketing-user-service"
+                exit 0
+              fi
+
+              echo "Waiting for user-service on main-2... ($i/30)"
+              sleep 3
+            done
+
+            echo "user-service health check failed on main-2"
+            docker logs --tail=100 ticketing-user-service
+            exit 1
+
+      - name: Prune Docker images on main-1 EC2
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            docker image prune -f
+
+      - name: Prune Docker images on main-2 EC2
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.EC2_HOST_2 }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
             docker image prune -f


### PR DESCRIPTION
### 📎 관련 이슈
- close #53 

### 📌 작업 내용
- `dev` 브랜치에 반영된 `user-service` 다중 EC2 순차 배포 설정을 `main` 브랜치에 반영합니다.
- 기존 단일 EC2 배포 구조에서 main-1, main-2 두 대의 EC2에 순차적으로 배포되도록 CD workflow를 수정했습니다.
- main-1 배포 및 health check 성공 후 main-2 배포를 진행하도록 구성했습니다.

### ✨ 변경 사항
- `user-service` CD workflow에서 main-1 EC2 배포 step 추가
- `user-service` CD workflow에서 main-2 EC2 배포 step 추가
- 각 EC2 배포 후 `http://localhost:20001/actuator/health` 기반 health check 수행
- 서버별 Docker image prune 수행
- 기존 GHCR image build/push 방식 유지

### 📝 리뷰 포인트 (선택)
- `EC2_HOST_2` GitHub Actions Secret이 추가되어 있어야 합니다.
- 이 PR이 `main`에 머지되면 `user-service` CD workflow가 실행될 수 있습니다.
- 배포 순서는 main-1 → main-2입니다.
- main-1 배포 또는 health check 실패 시 main-2 배포로 넘어가지 않도록 구성했습니다.

### 🧠 기타 참고 사항
- 기존 `EC2_HOST`는 main-1 EC2를 의미합니다.
- `EC2_HOST_2`는 main-2 EC2를 의미합니다.
- 이번 작업은 전체 서비스에 다중 EC2 순차 배포를 적용하기 전, `user-service`에 먼저 적용하는 검증성 변경입니다.